### PR TITLE
Handle alias node in key detector parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $
 Add these options similarly to the path option seen above.
 
 | Option | Description | Default |
-| ------------- | ------------- | ------------- | ------------- |
+| ------------- | ------------- | ------------- |
 | `debug` | Debug logging | `false` |
 | `disable_ext_check` | Disable file extension check | `false` |
 | `exclude_paths` | List of files or paths to exclude from linting | `nil` |

--- a/lib/yamllint/linter.rb
+++ b/lib/yamllint/linter.rb
@@ -116,7 +116,7 @@ module YamlLint
 
     # Check that the data is valid YAML
     def check_syntax_valid?(yaml_data, errors_array)
-      YAML.safe_load(yaml_data)
+      YAML.safe_load(yaml_data, [], [], aliases: true)
       true
     rescue YAML::SyntaxError => e
       errors_array << e.message
@@ -172,6 +172,13 @@ module YamlLint
             parse_recurse(n)
             hash_end(@last_key.last)
             is_key = false
+            @last_key.pop
+          when 'Psych::Nodes::Alias'
+            is_key = false
+            @last_key.last << n.anchor
+            add_value(n.anchor, @last_key.last)
+            msg = "Anchor: #{n.anchor}, key: #{is_key}, last_key: #{@last_key}"
+            YamlLint.logger.debug { msg }
             @last_key.pop
           end
         end

--- a/lib/yamllint/version.rb
+++ b/lib/yamllint/version.rb
@@ -2,5 +2,5 @@
 #
 # YamlLint checks YAML files for correct syntax
 module YamlLint
-  VERSION = '0.0.9'.freeze
+  VERSION = '0.0.10'.freeze
 end

--- a/spec/data/invalid_anchor.yaml
+++ b/spec/data/invalid_anchor.yaml
@@ -1,0 +1,12 @@
+---
+foo: bar
+my_alias: &my_alias
+  alias: alias_value
+my_hash:
+  <<: *my_alias
+  foo1: bar1
+  foo2: bar1
+  foo3: bar1
+  <<: *my_alias
+my_hash2:
+  <<: *my_alias

--- a/spec/data/valid_anchor.yaml
+++ b/spec/data/valid_anchor.yaml
@@ -1,0 +1,9 @@
+---
+foo: bar
+my_alias: &my_alias
+  alias: alias_value
+my_hash:
+  <<: *my_alias
+  foo1: bar1
+  foo2: bar1
+  foo3: bar1

--- a/spec/linter_spec.rb
+++ b/spec/linter_spec.rb
@@ -20,6 +20,10 @@ describe 'YamlLint::Linter' do
     expect(linter.check(spec_data('valid_very_complex.yaml'))).to be(true)
   end
 
+  it 'should be happy with a valid YAML file with anchor' do
+    expect(linter.check(spec_data('valid_anchor.yaml'))).to be(true)
+  end
+
   it 'should have 0 error count with a valid YAML file' do
     linter.check(spec_data('valid.yaml'))
     expect(linter.errors_count).to eq(0)
@@ -69,5 +73,9 @@ describe 'YamlLint::Linter' do
 
   it 'should be unhapy with a YAML file full of spaces' do
     expect(linter.check(spec_data('spaces.yaml'))).to be(false)
+  end
+
+  it 'should be unhappy with a YAML file with duplicate anchor in same level' do
+    expect(linter.check(spec_data('invalid_anchor.yaml'))).to be(false)
   end
 end


### PR DESCRIPTION
See https://github.com/shortdudey123/yamllint/pull/36 for the defect behavior.

This patch will:
1. Parse alias node in yaml tree so that the remaining key value parsing will be in order
2. Will check for duplicated alias reference within the same level